### PR TITLE
fix homepage hover gifs padding

### DIFF
--- a/src/components/Styles.js
+++ b/src/components/Styles.js
@@ -468,6 +468,7 @@ const Styles = styled.div`
       &:hover .hover-gif__img {
         height: 100%;
         width: 100%;
+        padding: 0;
       }
       figure {
         height: 0%;


### PR DESCRIPTION
how to test:
- run local build and got to homepage (http://localhost:8000/)
- hover around screen until a gif pops up
- make sure the gif is round

before:
![Screenshot 2020-05-27 06 46 13](https://user-images.githubusercontent.com/4466585/83015253-c5052f80-9fe5-11ea-8169-da8a8714c85a.png)

after:
![Screenshot 2020-05-27 06 43 40](https://user-images.githubusercontent.com/4466585/83015264-c9314d00-9fe5-11ea-9bd7-ad876e899a0f.png)
